### PR TITLE
Clean up src/volume-meter.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,5 +8,7 @@ module.exports = {
     ecmaVersion: 12,
     sourceType: 'module',
   },
-  rules: {},
+  rules: {
+    'no-plusplus': 0,
+  },
 };

--- a/src/volume-meter.js
+++ b/src/volume-meter.js
@@ -38,18 +38,79 @@ clipLag: how long you would like the "clipping" indicator to show
 Access the clipping through node.checkClipping(); use node.shutdown to get rid of it.
 */
 
-let audioContext;
-let mediaStreamSource;
-let meter;
-const meterInitialized = false;
+function volumeAudioProcess(event) {
+  const buf = event.inputBuffer.getChannelData(0);
+  const bufLength = buf.length;
+  let sum = 0;
+  let x;
 
-export function initVolumeMeter() {
+  // Do a root-mean-square on the samples: sum up the squares...
+  for (let i = 0; i < bufLength; i++) {
+    x = buf[i];
+    if (Math.abs(x) >= this.clipLevel) {
+      this.clipping = true;
+      this.lastClip = window.performance.now();
+    }
+    sum += x * x;
+  }
+
+  // ... then take the square root of the sum.
+  const rms = Math.sqrt(sum / bufLength);
+
+  // Now smooth this out with the averaging factor applied
+  // to the previous sample - take the max here because we
+  // want "fast attack, slow release."
+  this.volume = Math.max(rms, this.volume * this.averaging);
+}
+
+function createAudioMeter(audioContext, clipLevel, averaging, clipLag) {
+  const processor = audioContext.createScriptProcessor(512);
+  processor.onaudioprocess = volumeAudioProcess;
+  processor.clipping = false;
+  processor.lastClip = 0;
+  processor.volume = 0;
+  processor.clipLevel = clipLevel || 0.98;
+  processor.averaging = averaging || 0.95;
+  processor.clipLag = clipLag || 750;
+
+  // this will have no effect, since we don't copy the input to the output,
+  // but works around a current Chrome bug.
+  processor.connect(audioContext.destination);
+
+  processor.checkClipping = () => {
+    if (!this.clipping) return false;
+    if ((this.lastClip + this.clipLag) < window.performance.now()) this.clipping = false;
+    return this.clipping;
+  };
+
+  processor.shutdown = () => {
+    this.disconnect();
+    this.onaudioprocess = null;
+  };
+
+  return processor;
+}
+
+export default function initVolumeMeter() {
+  function didntGetStream() {
+    alert('Stream generation failed.');
+  }
+
   // volume meter
   // monkeypatch Web Audio
-  window.AudioContext = window.AudioContext || window.webkitAudioContext;
+  window.AudioContext ??= window.webkitAudioContext;
 
   // grab an audio context
-  audioContext = new AudioContext();
+  const audioContext = new AudioContext();
+
+  function gotStream(stream) {
+    // Create an AudioNode from the stream.
+    const mediaStreamSource = audioContext.createMediaStreamSource(stream);
+
+    // Create a new volume meter and connect it.
+    const meter = createAudioMeter(audioContext);
+    mediaStreamSource.connect(meter);
+  }
 
   // Attempt to get audio input
   try {
@@ -75,72 +136,4 @@ export function initVolumeMeter() {
   } catch (e) {
     alert(`getUserMedia threw exception :${e}`);
   }
-
-  function didntGetStream() {
-    alert('Stream generation failed.');
-  }
-
-  mediaStreamSource = null;
-
-  function gotStream(stream) {
-    // Create an AudioNode from the stream.
-    mediaStreamSource = audioContext.createMediaStreamSource(stream);
-
-    // Create a new volume meter and connect it.
-    meter = createAudioMeter(audioContext);
-    mediaStreamSource.connect(meter);
-  }
-}
-
-function createAudioMeter(audioContext, clipLevel, averaging, clipLag) {
-  const processor = audioContext.createScriptProcessor(512);
-  processor.onaudioprocess = volumeAudioProcess;
-  processor.clipping = false;
-  processor.lastClip = 0;
-  processor.volume = 0;
-  processor.clipLevel = clipLevel || 0.98;
-  processor.averaging = averaging || 0.95;
-  processor.clipLag = clipLag || 750;
-
-  // this will have no effect, since we don't copy the input to the output,
-  // but works around a current Chrome bug.
-  processor.connect(audioContext.destination);
-
-  processor.checkClipping =		function () {
-		  if (!this.clipping) return false;
-		  if ((this.lastClip + this.clipLag) < window.performance.now()) this.clipping = false;
-		  return this.clipping;
-  };
-
-  processor.shutdown =		function () {
-		  this.disconnect();
-		  this.onaudioprocess = null;
-  };
-
-  return processor;
-}
-
-function volumeAudioProcess(event) {
-  const buf = event.inputBuffer.getChannelData(0);
-  const bufLength = buf.length;
-  let sum = 0;
-  let x;
-
-  // Do a root-mean-square on the samples: sum up the squares...
-  for (let i = 0; i < bufLength; i++) {
-    	x = buf[i];
-    	if (Math.abs(x) >= this.clipLevel) {
-    		this.clipping = true;
-    		this.lastClip = window.performance.now();
-    	}
-    	sum += x * x;
-  }
-
-  // ... then take the square root of the sum.
-  const rms = Math.sqrt(sum / bufLength);
-
-  // Now smooth this out with the averaging factor applied
-  // to the previous sample - take the max here because we
-  // want "fast attack, slow release."
-  this.volume = Math.max(rms, this.volume * this.averaging);
 }


### PR DESCRIPTION
This pull request should resolve some warnings and errors from ESLint. It also disables ESLint's complaining when an unary operator is used.